### PR TITLE
Don't show PRs in issues to close, improve help text for WC issues prompt

### DIFF
--- a/tasks/github.js
+++ b/tasks/github.js
@@ -42,7 +42,7 @@ module.exports = (gulp, plugins, sake) => {
           name: 'issues_to_close',
           message: 'Release issues exist for ' + sake.getPluginName() + '. Select an issue this release should close.',
           choices: function () {
-            let choices = result.data.map((result) => {
+            let choices = result.data.filter((result) => !result.pull_request).map((result) => {
               return {
                 value: result.number,
                 name: 'Close issue #' + result.number + ': ' + result.html_url
@@ -87,9 +87,9 @@ module.exports = (gulp, plugins, sake) => {
           inquirer.prompt([{
             type: 'checkbox',
             name: 'issues_to_close',
-            message: 'Issues on WC repo exist for ' + sake.getPluginName() + '. Select an issue this release should close.',
+            message: 'Issues on WC repo exist for ' + sake.getPluginName() + '. Select an issue this release should close. To skip, press Enter without selecting anything.',
             choices: function () {
-              let choices = result.data.sort().map((result) => {
+              let choices = result.data.filter((result) => !result.pull_request).sort().map((result) => {
                 return {
                   value: result.number,
                   name: 'Close issue #' + result.number + ': ' + result.html_url


### PR DESCRIPTION
Addresses #26 and partly #25

With regards to #25, I've added some help text to clarify that you can skip making a choice by simply not selecting anything and pressing Enter.

I'd have to set up copies of WC repos in order to test whether the issues actually get closed or not, which I can handle in a separate PR.