### PR TITLE
Update replace:version task to process readme.md files

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -136,11 +136,12 @@ module.exports = (gulp, plugins, sake) => {
       return { match: version, replacement: () => sake.getVersionBump() }
     })
 
-    const filterChangelog = plugins.filter('**/{readme.txt,changelog.txt}', { restore: true })
+    const filterChangelog = plugins.filter('**/{readme.md,readme.txt,changelog.txt}', { restore: true })
     const date = dateFormat(new Date(), 'yyyy.mm.dd')
 
     return gulp.src([
       `${sake.config.paths.src}/**/*.php`,
+      `${sake.config.paths.src}/readme.md`,
       `${sake.config.paths.src}/readme.txt`,
       `${sake.config.paths.src}/changelog.txt`,
       `${sake.config.paths.assetPaths.js}/**/*.{coffee,js}`,


### PR DESCRIPTION
This PR updates the `replace:version` task to replace the version and deploy date on the `readme.md` file in addition to `changelog.txt` and `readme.txt` files.

As mentioned in https://github.com/skyverge/woocommerce-extra-product-sorting-options/pull/21#pullrequestreview-337452332, this would be useful for deploys of the [Extra Product Sorting Options plugin](https://github.com/skyverge/woocommerce-extra-product-sorting-options/pull/21) and other plugins that include copy of the changelog in the `readme.md` file.