### PR TITLE
Remove @octokit/rest deprecation messages

### DIFF
--- a/tasks/github.js
+++ b/tasks/github.js
@@ -1,3 +1,4 @@
+const { createTokenAuth } = require("@octokit/auth-token")
 const { Octokit: GitHub } = require('@octokit/rest')
 const inquirer = require('inquirer')
 const fs = require('fs')
@@ -15,10 +16,8 @@ module.exports = (gulp, plugins, sake) => {
     if (!githubInstance) {
       githubInstance = new GitHub({
         debug: false,
-        auth: {
-          username: process.env.GITHUB_USERNAME,
-          password: process.env.GITHUB_API_KEY
-        }
+        authStrategy: createTokenAuth,
+        auth: process.env.GITHUB_API_KEY
       })
     }
 


### PR DESCRIPTION
# Summary

This PR removes several deprecation messages triggered by `@octokit/rest`.

## Details



<details>
	<summary><code>const Octokit = require("@octokit/rest")</code> is deprecated. Use <code>const { Octokit } = require("@octokit/rest")</code> instead</summary>

```node
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
Deprecation: [@octokit/rest] Setting the "new Octokit({ auth })" option to an object without also setting the "authStrategy" option is deprecated and will be removed in v17. See (https://octokit.github.io/rest.js/#authentication)
    at authenticationPlugin (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/plugins/authentication/index.js:58:5)
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/lib/constructor.js:26:37
    at Array.forEach (<anonymous>:null:null)
    at new Octokit (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/lib/constructor.js:26:11)
    at new DeprecatedOctokit (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/index.js:29:10)
    at getGithub (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/sake/tasks/github.js:16:24)
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/sake/tasks/github.js:31:18
    at github:get_rissue (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:426:14)
    at runBound (domain.js:439:12)
    at asyncRunner (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/async-done/index.js:55:18)
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
 {
  name: 'Deprecation'
}
```
</details>

<details>
	<summary>"file" parameter is deprecated for ".repos.uploadReleaseAsset()". Use "data" instead</summary>

```node
Deprecation: [@octokit/rest] "file" parameter is deprecated for ".repos.uploadReleaseAsset()". Use "data" instead
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js:13145:26
    at Array.forEach (<anonymous>:null:null)
    at Object.patchedMethod [as uploadReleaseAsset] (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js:13142:26)
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/sake/tasks/github.js:207:22
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
 {
  name: 'Deprecation'
}
```
</details>

<details>
	<summary>Setting the "new Octokit({ auth })" option to an object without also setting the "authStrategy" option is deprecated and will be removed in v17.</summary>

```node
Deprecation: [@octokit/rest] Setting the "new Octokit({ auth })" option to an object without also setting the "authStrategy" option is deprecated and will be removed in v17. See (https://octokit.github.io/rest.js/#authentication)
    at authenticationPlugin (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/plugins/authentication/index.js:58:5)
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/lib/constructor.js:26:37
    at Array.forEach (<anonymous>:null:null)
    at new Octokit (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/@octokit/rest/lib/constructor.js:26:11)
    at getGithub (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/sake/tasks/github.js:16:24)
    at /Users/wvega/Projects/skyverge/wc-plugins/node_modules/sake/tasks/github.js:31:18
    at github:get_rissue (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:426:14)
    at runBound (domain.js:439:12)
    at asyncRunner (/Users/wvega/Projects/skyverge/wc-plugins/node_modules/async-done/index.js:55:18)
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
 {
  name: 'Deprecation'
}
```
</details>

## QA

I deployed WooCommerce Tab Manager using this version, so I don't expect QA to show any errors.

You can either try it on another deploy or run the following task to test the output.

### Setup

1. Update `wc-plugins/package.json` to use version `github:skyverge/sake#remove-deprecation-messages` of sake.
1. Run `npm install`

### Cases

1. `cd` into `wc-plugins/woocommerce-google-analytics-pro`
1. Execute `npx sake github:get_rissue`
    - [x] Sake prompts you to select an issue to close
    - [x] No deprecation warnings are shown

### Teardown

1. Update `wc-plugins/package.json` to use version `github:skyverge/sake` of sake.
1. Run `npm install`