### PR TITLE
Skip "deploy to production repo" tasks for WooCommerce.com plugins

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -198,18 +198,6 @@ module.exports = (gulp, plugins, sake) => {
       'github:create_release'
     ]
 
-    if (sake.config.deploy.type === 'wc' && sake.config.deploy.production) {
-      tasks = tasks.concat([
-        function (cb) {
-          sake.options.owner = sake.config.deploy.production.owner
-          sake.options.repo = sake.config.deploy.production.name
-          sake.options.prefix_release_tag = false
-          cb()
-        },
-        'github:create_release'
-      ])
-    }
-
     return gulp.series(tasks)(done)
   })
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -79,6 +79,10 @@ module.exports = (gulp, plugins, sake) => {
       tasks.push('prompt:wc_upload')
     }
 
+    if (sake.config.deploy.type === 'wp') {
+      tasks.push('deploy_to_wp_repo')
+    }
+
     // finally, create a docs issue, if necessary
     tasks.push('github:docs_issue')
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -69,8 +69,6 @@ module.exports = (gulp, plugins, sake) => {
         sake.buildPluginConfig()
         cb()
       },
-      // deploy to 3rd party repo
-      'deploy_to_production_repo',
       // create the zip, which will be attached to the releases
       'compress',
       // create releases, attaching the zip

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -61,7 +61,7 @@ module.exports = (gulp, plugins, sake) => {
       // ensure the required framework version is installed
       'deploy:validate_framework_version',
       // grab issues to close with commit
-      'get_issues_to_close',
+      'github:get_rissue',
       // git commit & push
       'shell:git_push_update',
       // rebuild plugin configuration (version number, etc)


### PR DESCRIPTION
## DO NOT MERGE until [this story](https://app.clubhouse.io/skyverge/story/34040/destroy-the-vendor-folder-on-deploy-before-re-installing-packages-via-composer) has been implemented

# Summary

This PR removes the `deploy to production repo` tasks for WooCommerce.com plugins and makes sure new versions of WordPress.org plugin are still committed to the plugin repository.

### Story: [CH 32131](https://app.clubhouse.io/skyverge/story/32131)

## Details

The PR also prevents sakè from trying to fetch issues to close from the production (mirror) repo and avoids attempting to create releases in those repos too.

## QA

### Setup

I wasn't sure how to test this myself, so I added a wiki page with instructions to test deploys for [WooCommerce.com plugins](https://github.com/skyverge/sake/wiki/Testing) and [WordPress.org plugins](https://github.com/skyverge/sake/wiki/Testing)

### Steps

#### WooCommerce.com deploys

Follow the instructions in [Test deploys to WooCommerce.com plugins](https://github.com/skyverge/sake/wiki/Testing#test-deploys-to-woocommercecom-plugins). Then, on your copy of a fork of the plugin repo, update your saké configuration to use a fake production target:

```js
module.exports = {
	// ...
	deploy: {
		type: 'wc',
		production: 'git@github.com:bruce/armored-vehicle-blueprint.git'
	},
	// ...
}
```

Make sure that the `deploy` property is set to an object with `type` property set to `wc` and the `production` property set to a fake Github repository. Sake is not supposed to interact with this production repository anymore.

1. Run `npm install` or `npm update` to make sure your are using this version of sakè
1. Commit the modifications to the `package.json` file if necessary
1. Commit the modifications to the sake configuration
1. Bump the development versions, add a test changelog entry, and commit those changes.
1. In the next step, remember to answer no to the prompt to upload the new version to WooCommerce.com
1. Run `npx sake deploy` 
    - [x] `deploy_to_production_repo` is not on the list of tasks executed
    - [x] sakè creates a new tag and a new release in the fork of the plugin repo
    - [x] sakè does not attempt to create a release in the fake production repo
    - [x] sakè prompts for confirmation to upload to the zip file to WooCommerce.com

#### WordPress.org deploys

Follow the instructions in [Fork a plugin that is distributed in the WordPress.org plugin repository](https://github.com/skyverge/sake/wiki/Testing#test-deploys-to-wordpressorg-plugin-repository). Then, on your copy of a fork of the plugin repo:

1. Run `npm install` or `npm update` to make sure your are using this version of sakè
1. Commit the modifications to the `package.json` file if necessary
1. Commit the modifications to the sake configuration
1. Bump the development versions, add a test changelog entry, and commit those changes.
1. Run `npx sake deploy` 
    - [x] `deploy_to_production_repo` is not on the list of tasks executed
    - [x] sakè creates a new tag and a new release in the fork of the plugin repo
    - [x] sakè creates a new tag in the SVN repository
    - [x] sakè updates the files int he trunk directory in the SVN repository
