### PR TITLE
Clean the vendor folder on build

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -5,10 +5,10 @@ module.exports = (gulp, plugins, sake) => {
   // - cleans the build directory
   // - compiles the plugin assets (linting where necessary)
   // - copies plugin files to the build directory
-  let tasks = ['clean:build', 'shell:composer_install', 'compile', 'copy:build']
+  let tasks = ['clean:build', 'shell:composer_status', 'clean:composer', 'shell:composer_install', 'compile', 'copy:build']
 
   if (sake.options['skip-composer']) {
-    tasks = _.without(tasks, 'shell:composer_install')
+    tasks = _.without(tasks, 'shell:composer_status', 'clean:composer', 'shell:composer_install')
   }
 
   gulp.task('build', gulp.series(tasks))

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -8,6 +8,11 @@ module.exports = (gulp, plugins, sake) => {
     return gulp.src(`${sake.config.paths.src}/${sake.config.paths.assets}/**/*.map`, defaultOptions).pipe(plugins.clean())
   })
 
+  // clean composer packages
+  gulp.task('clean:composer', () => {
+    return gulp.src(`${sake.config.paths.vendor}`, defaultOptions).pipe(plugins.clean())
+  })
+
   // clean (empty) build dir
   gulp.task('clean:build', () => {
     return gulp.src([

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -185,6 +185,15 @@ module.exports = (gulp, plugins, sake) => {
     exec('git stash apply', done)
   })
 
+  gulp.task('shell:composer_status', (done) => {
+    if (fs.existsSync(path.join(process.cwd(), 'composer.json'))) {
+      exec('composer status -v', done)
+    } else {
+      log.info('No composer.json found, skipping composer status')
+      done()
+    }
+  })
+
   gulp.task('shell:composer_install', (done) => {
     if (fs.existsSync(path.join(process.cwd(), 'composer.json'))) {
       exec('composer install --no-dev', done)


### PR DESCRIPTION
# Summary

Cleans the vendor folder before running `composer install`

### Story: [CH 34040](https://app.clubhouse.io/skyverge/story/34040)

## Details

Ensures the versions installed by composer are not modified locally.

This PR adds a `shell::composer_status` task, which runs `composer status`. If any local changes are found, build halts with an error. I figured it would be best to check and halt instead of blindly cleaning `vendor` and reinstalling, in case the dev made local changes that are relied upon by the plugin but forgotten. This allows the dev to assess the local changes.

The `vendor` directory is still removed and reinstalled.

## QA

### Setup

- Configur sake for [local development](https://github.com/skyverge/sake/wiki/Using-a-development-version-of-Saké)

### Steps

1. Run `sake build` for a plugin
    - [x] The plugin in `/build` contains the `vendor` packages
1. Manually modify a file from one of the packages like the framework
1. Run `sake build`
    - [x] The build fails with an error

## Before merge

- [ ] Any of our plugins that don't have `vendor` in root have `paths.vendor` defined in their `sake.config.js` file
- [ ] A full deploy has been run from this branch and confirmed to include vendor packages correctly