### PR TITLE
Exclude docker-compose.yml and wp-bootstrap.sh from builds

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -26,6 +26,8 @@ module.exports = (gulp, plugins, sake) => {
       `!${sake.config.paths.src}/**/.travis.yml`,
       `!${sake.config.paths.src}/**/phpunit.xml`,
       `!${sake.config.paths.src}/**/phpunit.travis.xml`,
+      `!${sake.config.paths.src}/**/docker-compose*.yml`,
+      `!${sake.config.paths.src}/**/wp-bootstrap.sh`,
       `!${sake.config.paths.src}/phpcs.xml`,
 
       // skip composer and npm files


### PR DESCRIPTION
# Summary

This PRs excludes the `docker-compose.yml` and `wp-bootstrap.sh` files from builds.

### Story: [CH 60710](https://app.clubhouse.io/skyverge/story/60710/update-sake-to-exclude-docker-compose-yml-and-wp-bootstrap-sh)

## QA

### Steps

1. Checkout [this Elavon branch](https://github.com/skyverge/wc-plugins/pull/3836) 
1. Update `../package.json` to use version `github:skyverge/sake#ch60710/update-sake-to-exclude-docker-compose-yml` of `sake`: 
1. Run `npm update sake --dev` to update
1. Run `npx sake build`
    - [x] The generated build directory does not include `docker-compose.yml`
    - [x] The generated build directory does not include `wp-bootstrap.sh`
