### PR TITLE
Allow plugin configs to define themselves as payment gateway plugins

### DIFF
--- a/lib/sake.js
+++ b/lib/sake.js
@@ -255,6 +255,10 @@ module.exports = (config, options) => {
       return false
     }
 
+    if (config.isPaymentGateway) {
+      return true
+    }
+
     let mainPluginFile = exports.getMainPluginFile(true)
 
     if (mainPluginFile) {


### PR DESCRIPTION
# Summary

Sake will exclude the framework's `payment-gateway` directory if it detects that the plugin is not a payment gateway by finding the gateway plugin class reference in the plugin files.

However, we should allow plugins that may have different file structures to override this.

### Story: [CH 67214](https://app.clubhouse.io/skyverge/story/67214)

## QA

- [x] Code review