### PR TITLE
Exclude tartufo files from copy task

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -50,6 +50,10 @@ module.exports = (gulp, plugins, sake) => {
       `!${sake.config.paths.src}/**/readme.md`,
       `!${sake.config.paths.src}/**/.{*}`, // any file starting with a dot
 
+      // skip tartufo files
+      `!${sake.config.paths.src}/**/tool.tartufo`,
+      `!${sake.config.paths.src}/**/exclude-patterns.txt`,
+
       // skip sake sake.config
       `!${sake.config.paths.src}/**/sake.config.js`
     ]


### PR DESCRIPTION
## Summary

Adds exclusions to `copy.js` so that tartufo files are not included in builds and (pre)releases.


#### Story: [CH 67233](https://app.clubhouse.io/skyverge/story/67233/add-exclusions-to-sake-to-avoid-copying-tartufo-files)

## QA

1. Try running `npx sake build` on a repository that contains tartufo files (e.g. Cybersource)
    - [x] The tartufo files will be included in build
1. Try running the same task from this dev branch 
    - [x] The tartufo files will not be included in the build