### PR TITLE
Update gulp-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/skyverge/sake/issues?state=open"
   },
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">=12"
   },
   "bin": {
     "sake": "bin/sake.js"
@@ -53,13 +53,13 @@
     "gulp-filter": "^5.1.0",
     "gulp-if": "^2.0.2",
     "gulp-imagemin": "^6.1.0",
-    "gulp-load-plugins": "^1.6.0",
+    "gulp-load-plugins": "^2.0.7",
     "gulp-phplint": "^0.9.0",
     "gulp-postcss": "^7.0.1",
     "gulp-rename": "^1.4.0",
     "gulp-replace": "^0.6.1",
     "gulp-replace-task": "^0.11.0",
-    "gulp-sass": "^3.2.1",
+    "gulp-sass": "^5.1.0",
     "gulp-sass-lint": "^1.4.0",
     "gulp-sourcemaps": "^2.6.4",
     "gulp-uglify": "^3.0.1",
@@ -75,6 +75,7 @@
     "parse-github-url": "^1.0.2",
     "request": "^2.88.0",
     "resolve-bin": "^0.4.0",
+    "sass": "^1.49.0",
     "semver": "^5.7.1",
     "shelljs": "^0.8.2",
     "strip-ansi": "^4.0.0",

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack-stream')
 const fs = require('fs')
 const path = require('path')
+const sass = require('gulp-sass')(require('sass'))
 
 module.exports = (gulp, plugins, sake) => {
   const pipes = require('../pipes/scripts.js')(plugins, sake)
@@ -111,7 +112,7 @@ module.exports = (gulp, plugins, sake) => {
       `!${sake.config.paths.assetPaths.css}/**/mixins.scss` // don't compile any mixins by themselves
     ])
       .pipe(plugins.sourcemaps.init())
-      .pipe(plugins.sass({ outputStyle: 'nested' }))
+      .pipe(sass({ outputStyle: 'expanded' }))
       .pipe(plugins.postcss(cssPlugins))
       .pipe(plugins.rename({ suffix: '.min' }))
       // ensure admin/ and frontend/ are removed from the source paths


### PR DESCRIPTION
This PR updates the gulp-sass version in order to ensure sake can be run on M1 macs, on which the current version does not support compiling SCSS:


```
[12:17:57] Starting 'compile:scss'...
[12:17:57] 'compile:scss' errored after 122 ms
[12:17:57] Error: Node Sass does not yet support your current environment: OS X Unsupported architecture (arm64) with Unsupported runtime (93)
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.14.1
```