### PR TITLE
Always include payment-gateway folder in build

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -94,10 +94,6 @@ module.exports = (gulp, plugins, sake) => {
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/${sake.config.paths.framework.general.css}/**/*.scss`,
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/${sake.config.paths.framework.gateway.css}/**/*.scss`
       ])
-
-      if (!sake.isFrameworkedPaymentGateway()) {
-        paths.push(`!${sake.config.paths.src}/${sake.config.paths.framework.base}/woocommerce/payment-gateway{,/**}`)
-      }
     }
 
     paths = paths.concat([


### PR DESCRIPTION
## Summary

It looks like that the `payment-gateway` dir of the FW will be excluded if a plugin itself using Sake is not a payment gateway. However,  we may need the `payment-gateway` folder to be available if the load order of the FW will assume that some files required by an actual payment gateway should be loaded from a non-payment gateway.

## QA

To test this, check the following

1. Run `npx sake build` from a payment gateway such as Intuit QBMS or another gateway
     - [ ] The `payment-gateway` folder of the FW will be copied into the build
1. Run `npx sake build` from a non-payment gateway such as Address Validation or AvaTax plugins
    - [ ] The `payment-gateway` folder of the FW will be not copied to the build
1. Follow [these instructions](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9) to run a local dev version of sake
1. Point the dev version to this branch
1. Run `sake build` from a non gateway plugin
    - [ ] The `payment gateway` folder is included in the build
1. Run `sake build` from a gateway plugin
   - [ ] The `payment gateway` folder is included in the build

