### PR TITLE
Skip manifest.xml from being included in builds

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -63,7 +63,7 @@ module.exports = (gulp, plugins, sake) => {
       `!${sake.config.paths.src}/**/.whitesource`,
 
       // skip manifest.xml
-      `!${sake.config.paths.src}/**/manifest.xml`,
+      `!${sake.config.paths.src}/manifest.xml`,
 
       // skip sake sake.config
       `!${sake.config.paths.src}/**/sake.config.js`

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -62,6 +62,9 @@ module.exports = (gulp, plugins, sake) => {
       // skip whitesource files
       `!${sake.config.paths.src}/**/.whitesource`,
 
+      // skip manifest.xml
+      `!${sake.config.paths.src}/**/manifest.xml`,
+
       // skip sake sake.config
       `!${sake.config.paths.src}/**/sake.config.js`
     ]


### PR DESCRIPTION
## Summary

Adds an exclusion for `manifest.xml` from being included in builds (copy.js task).

This file contains metadata related to GoLF translations support and is not necessary for the plugin to handle translations, once these are included in the i18n folder.