### PR TITLE
Generate POT file using WP CLI i18n make-pot command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ let defaults = {
   tasks: {
     makepot: {
       reportBugsTo: 'https://woocommerce.com/my-account/marketplace-ticket-form/',
-      domainPath: '/i18n/languages'
+      domainPath: 'i18n/languages'
     },
     watch: {
       useBrowserSync: process.env.USE_BROWSERSYNC || false

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "lodash": "^4.17.15",
     "minimist": "^1.2.0",
     "node-notifier": "^5.4.3",
-    "node-wp-i18n": "^1.2.1",
     "parse-git-config": "^2.0.3",
     "parse-github-url": "^1.0.2",
     "request": "^2.88.0",
@@ -87,7 +86,7 @@
     "gulp-debug": "^3.2.0",
     "standard": "^11.0.1"
   },
-  "overrides" : {
+  "overrides": {
     "@octokit/rest": {
       "universal-user-agent": "6.0.0"
     }

--- a/tasks/makepot.js
+++ b/tasks/makepot.js
@@ -8,9 +8,7 @@ module.exports = (gulp, plugins, sake) => {
     const domainPath = ( options.domainPath || 'i18n/languages' ) + '/' + sake.config.plugin.id + '.pot'
     const excludedPaths = ['.github/.*', 'lib/.*', 'vendor/.*', 'tests/.*', 'node_modules/.*']
     const excluded = excludedPaths.map((path) => `--exclude="${path}"`).join(' ')
-    const headers = options.reportBugsTo
-      ? `--headers='{"Report-Msgid-Bugs-To": "${options.reportBugsTo}"}'`
-      : '';
+    const headers = options.reportBugsTo ? `--headers='{"Report-Msgid-Bugs-To": "${options.reportBugsTo}"}'` : ''
 
     log.info('Generating POT file...')
 

--- a/tasks/makepot.js
+++ b/tasks/makepot.js
@@ -12,7 +12,7 @@ module.exports = (gulp, plugins, sake) => {
 
     log.info('Generating POT file...')
 
-    let result = shell.exec(`wp i18n make-pot . ${domainPath}  ${headers} ${excluded}` )
+    let result = shell.exec(`wp i18n make-pot . ${domainPath}  ${headers} ${excluded}`)
 
     if (result.code !== 0) {
       sake.throwError(`Error while generating POT file: ${result.stderr ?? 'unknown error.'}`)

--- a/tasks/makepot.js
+++ b/tasks/makepot.js
@@ -1,21 +1,28 @@
-const wpi18n = require('node-wp-i18n')
+const log = require('fancy-log')
+const shell = require('shelljs')
 
-// generate POT files
+// generate POT files using wp cli
 module.exports = (gulp, plugins, sake) => {
-  gulp.task('makepot', () => {
-    let options = {
-      cwd: `${process.cwd()}/${sake.config.paths.src}`,
-      domainPath: sake.config.tasks.makepot.domainPath,
-      exclude: [ 'lib/*', 'vendor/.*', 'tests/.*', 'node_modules/.*' ],
-      potHeaders: { 'report-msgid-bugs-to': sake.config.tasks.makepot.reportBugsTo },
-      processPot: function (pot) {
-        delete pot.headers['x-generator']
-        return pot
-      }, // jshint ignore:line
-      type: 'wp-plugin',
-      updateTimestamp: false
-    }
+  gulp.task('makepot', (done) => {
+    const options = sake.config.tasks.makepot
+    const domainPath = ( options.domainPath || 'i18n/languages' ) + '/' + sake.config.plugin.id + '.pot'
+    const excludedPaths = ['.github/.*', 'lib/.*', 'vendor/.*', 'tests/.*', 'node_modules/.*']
+    const excluded = excludedPaths.map((path) => `--exclude="${path}"`).join(' ')
+    const headers = options.reportBugsTo
+      ? `--headers='{"Report-Msgid-Bugs-To": "${options.reportBugsTo}"}'`
+      : '';
 
-    return wpi18n.makepot(options)
+    log.info('Generating POT file...')
+
+    let result = shell.exec(`wp i18n make-pot . ${domainPath}  ${headers} ${excluded}` )
+
+    if (result.code !== 0) {
+      sake.throwError(`Error while generating POT file: ${result.stderr ?? 'unknown error.'}`)
+      done(result.stderr)
+    } else {
+      log.info(result.stdout)
+      log.error(result.stderr)
+      done()
+    }
   })
 }


### PR DESCRIPTION
## Summary

This PR replaces the `node-wp-i18n` package to generate a pot file with `wp i18n make-pot` WP CLI command.

This command will also parse any sources from .js files, such as those added by blocks.

## QA 

Please review #72  first.

To test this, [follow this guide](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9) to use a dev copy of Sake and test it out on any frameworked plugin that uses Sake, running `sake makepot`: A new, updated potfile should be generated matching the previous one. If you try it on a plugin that has gettext data in JS, those strings should be captured as well in the final potfile. For example, check this PR for Auth Net: https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim/pull/91
