### PR TITLE
Update octokit/gihtuib to latest version, fix auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/skyverge/sake/issues?state=open"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "bin": {
     "sake": "bin/sake.js"
@@ -22,7 +22,7 @@
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
-    "@octokit/rest": "16.43.2",
+    "@octokit/rest": "20.0.2",
     "@skyverge/eslint-config": "^0.1.3",
     "@wordpress/babel-plugin-makepot": "^3.2.0",
     "async": "^2.6.3",

--- a/tasks/github.js
+++ b/tasks/github.js
@@ -1,4 +1,3 @@
-const { createTokenAuth } = require('@octokit/auth-token')
 const { Octokit: GitHub } = require('@octokit/rest')
 const inquirer = require('inquirer')
 const fs = require('fs')

--- a/tasks/github.js
+++ b/tasks/github.js
@@ -16,7 +16,6 @@ module.exports = (gulp, plugins, sake) => {
     if (!githubInstances[target]) {
       githubInstances[target] = new GitHub({
         debug: false,
-        authStrategy: createTokenAuth,
         auth: process.env[`SAKE_${target.toUpperCase()}_GITHUB_API_KEY`] || process.env.GITHUB_API_KEY
       })
     }


### PR DESCRIPTION
# Summary

This PR updates the `@octokit/rest` client to latest version (20.0.2), and fixes authentication using personal access tokens.

- The latest version supports Apple Silicon macs
- It's no longer necessary to pass the `createTokenAuth` strategy when creating a GH instances (in fact, doing so will cause the auth to fail)
- Minimum node version is also bumped to 18 (which is what octokit supports)