### PR TITLE
Update manifest.xml exclusion path

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -65,8 +65,9 @@ module.exports = (gulp, plugins, sake) => {
       // skip manifest.xml
       `!${sake.config.paths.src}/**/manifest.xml`,
 
-      // skip sake sake.config
-      `!${sake.config.paths.src}/**/sake.config.js`
+      // skip build config files
+      `!${sake.config.paths.src}/**/sake.config.js`,
+      `!${sake.config.paths.src}/**/postcss.config.js`,
     ]
 
     if (sake.config.framework) {

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -63,7 +63,7 @@ module.exports = (gulp, plugins, sake) => {
       `!${sake.config.paths.src}/**/.whitesource`,
 
       // skip manifest.xml
-      `!${sake.config.paths.src}/manifest.xml`,
+      `!${sake.config.paths.src}/**/manifest.xml`,
 
       // skip sake sake.config
       `!${sake.config.paths.src}/**/sake.config.js`


### PR DESCRIPTION
The `manifest.xml` file still makes into a build. We need to update the exclusion path as per this PR.

I've also added `postcss.config.js` to the exclusions since it popped in some builds.