### PR TITLE
Rebuild config before git push tasks

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -66,8 +66,6 @@ module.exports = (gulp, plugins, sake) => {
       'deploy:validate_framework_version',
       // grab issues to close with commit
       'github:get_rissue',
-      // git commit & push
-      'shell:git_push_update',
       // rebuild plugin configuration (version number, etc)
       function rebuildPluginConfig (cb) {
         sake.buildPluginConfig()

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -66,13 +66,13 @@ module.exports = (gulp, plugins, sake) => {
       'deploy:validate_framework_version',
       // grab issues to close with commit
       'get_issues_to_close',
-      // git commit & push
-      'shell:git_push_update',
       // rebuild plugin configuration (version number, etc)
       function rebuildPluginConfig (cb) {
         sake.buildPluginConfig()
         cb()
       },
+      // git commit & push
+      'shell:git_push_update',
       // deploy to 3rd party repo
       'deploy_to_production_repo',
       // create the zip, which will be attached to the releases

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -95,7 +95,7 @@ module.exports = (gulp, plugins, sake) => {
   gulp.task('shell:git_push_update', (done) => {
     let command = [
       'git add -A',
-      'git commit -m "' + sake.config.plugin.name + ': ' + sake.getVersionBump() + ' Versioning"' + (sake.options.release_issue_to_close ? ' -m "Closes #' + sake.options.release_issue_to_close + '"' : ''),
+      'git commit -m "' + sake.config.plugin.name + ': ' + sake.getPluginVersion() + ' Versioning"' + (sake.options.release_issue_to_close ? ' -m "Closes #' + sake.options.release_issue_to_close + '"' : ''),
       'git push',
       'echo git up to date!'
     ].join(' && ')
@@ -152,7 +152,7 @@ module.exports = (gulp, plugins, sake) => {
       let command = [
         'cd ' + sake.getProductionRepoPath(),
         'git add -A',
-        'git commit -m "Update ' + sake.config.plugin.name + ' to ' + sake.getVersionBump() + '"' + closeIssues,
+        'git commit -m "Update ' + sake.config.plugin.name + ' to ' + sake.getPluginVersion() + '"' + closeIssues,
         'git push'
       ].join(' && ')
 


### PR DESCRIPTION
# Summary

Sometimes git tasks fail in the middle of the deploy and we need to re-run them manually, without running the previously successful tasks. A recent example is that a push to the WC mirror repo failed, and I ran the `deploy_to_production_repo` task, which was otherwise successful, but the commit message was `Update WooCommerce Authorize.Net Gateway to undefined`. This happened because the git push tasks expect a version bump to be present, but this is not the case if we're running this task separately. 

This PR makes 2 changes:
* rebuild the plugin config _before_ any git commit/push tasks - this will load the new plugin version from the changelog
* use `sake.getPluginVersion()` instead of `sake.getVersionBump()` in git push tasks, to ensure the commit message uses the updated version number

Applying this change will make sure that if any git tasks in the deploy process fail, we should be able to re-run them without having to remember to provide any CLI options, such as the version bump.