### PR TITLE
update webpack-stream to latest version, set mode to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strip-ansi": "^4.0.0",
     "underscore.string": "^3.3.4",
     "undertaker-forward-reference": "^1.0.2",
-    "webpack-stream": "^5.2.1"
+    "webpack-stream": "^7.0.0"
   },
   "devDependencies": {
     "gulp-debug": "^3.2.0",

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -66,6 +66,7 @@ module.exports = (gulp, plugins, sake) => {
       return gulp.src(sake.config.paths.assetPaths.blockSources)
         .pipe(plugins.sourcemaps.init())
         .pipe(webpack({
+          mode: 'production',
           entry: `${blockPath}/${blockSrc[0]}`,
           output: {
             filename: path.basename(blockSrc[0], '.js') + '.min.js'


### PR DESCRIPTION
# Summary

This PR updates the `webpack-stream` dep to latest version (7.0.0), which seems to fix an issue with the `compile:blocks` task failing on newer versions of node.

## QA

- Follow steps to use the [dev version locally](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
- Running `sake compile:scripts` in a repo like Memberships is successful and does not throw errors