### PR TITLE
Always include payment-gateway files for autoloading when needed

### DIFF
--- a/lib/sake.js
+++ b/lib/sake.js
@@ -138,9 +138,13 @@ module.exports = (config, options) => {
 
       config.plugin.frameworkVersion = this.getFrameworkVersion()
 
+      let requiredFrameworkVersion = this.getRequiredFrameworkVersion();
+
       if (config.framework === 'v5') {
-        config.plugin.requiredFrameworkVersion = this.getRequiredFrameworkVersion()
+        config.plugin.requiredFrameworkVersion = requiredFrameworkVersion
       }
+
+      config.autoload = config.autoload || semver.gte(requiredFrameworkVersion, '5.14.0')
     }
   }
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -98,10 +98,6 @@ module.exports = (gulp, plugins, sake) => {
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/${sake.config.paths.framework.general.css}/**/*.scss`,
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/${sake.config.paths.framework.gateway.css}/**/*.scss`
       ])
-
-      if (!sake.isFrameworkedPaymentGateway()) {
-        paths.push(`!${sake.config.paths.src}/${sake.config.paths.framework.base}/woocommerce/payment-gateway{,/**}`)
-      }
     }
 
     paths = paths.concat([

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const semver = require('semver')
 
 module.exports = (gulp, plugins, sake) => {
   // copy files from source to build
@@ -128,7 +129,11 @@ module.exports = (gulp, plugins, sake) => {
       paths.push(`!${sake.config.paths.vendor}/bin{,/**}`)
 
       // skip composer autoloader, unless required
-      if (!sake.config.autoload && sake.config.paths.vendor) {
+      if (
+        semver.lt(sake.getRequiredFrameworkVersion(), '5.14.0') && // autoloading is required since FW v5.14.0
+        !sake.config.autoload &&
+        sake.config.paths.vendor
+      ) {
         paths = paths.concat([
           `!${sake.config.paths.vendor}/composer{,/**}`,
           `!${sake.config.paths.vendor}/autoload.php`

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -129,11 +129,7 @@ module.exports = (gulp, plugins, sake) => {
       paths.push(`!${sake.config.paths.vendor}/bin{,/**}`)
 
       // skip composer autoloader, unless required
-      if (
-        semver.lt(sake.getRequiredFrameworkVersion(), '5.14.0') && // autoloading is required since FW v5.14.0
-        !sake.config.autoload &&
-        sake.config.paths.vendor
-      ) {
+      if (!sake.config.autoload) {
         paths = paths.concat([
           `!${sake.config.paths.vendor}/composer{,/**}`,
           `!${sake.config.paths.vendor}/autoload.php`

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -75,8 +75,7 @@ module.exports = (gulp, plugins, sake) => {
       paths = paths.concat([
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/*`,
         `!${sake.config.paths.src}/${sake.config.paths.framework.base}/grunt{,/**}`,
-        `${sake.config.paths.src}/${sake.config.paths.framework.base}/license.txt`,
-        `!${sake.config.paths.src}/${sake.config.paths.framework.base}/woocommerce/payment-gateway/templates{,/**}`
+        `${sake.config.paths.src}/${sake.config.paths.framework.base}/license.txt`
       ])
 
       if (sake.config.framework === 'v5') {


### PR DESCRIPTION
### Summery

Update the `copy:build` task to: 
- Always include payment-gateway files for autoloading when needed in [class aliases](https://github.com/godaddy-wordpress/wc-plugin-framework/blob/master/woocommerce/class-sv-wc-plugin.php#L456-L480)
- Always include composer autoloader if the plugin requires framework >= [v5.14.0](https://github.com/godaddy-wordpress/wc-plugin-framework/releases/tag/5.14.0)

### QA 

- Follow steps in QA section of https://github.com/gdcorp-partners/woocommerce-product-retailers/pull/88