### PR TITLE
Update WooCommerce deployment API

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dottie": "^2.0.0",
     "eslint": "^6.2.2",
     "fancy-log": "^1.3.2",
+    "form-data": "^4.0.1",
     "gulp": "^4.0.0",
     "gulp-babel": "^7.0.1",
     "gulp-clean": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "node-notifier": "^5.4.3",
     "parse-git-config": "^2.0.3",
     "parse-github-url": "^1.0.2",
-    "request": "^2.88.0",
     "resolve-bin": "^0.4.0",
     "sass": "^1.49.0",
     "semver": "^5.7.1",

--- a/tasks/wc.js
+++ b/tasks/wc.js
@@ -39,6 +39,8 @@ module.exports = (gulp, plugins, sake) => {
           console.debug(res.data)
         }
 
+        // NOTE: when we get this response code, the HTTP status is `400` --  does axios throw an exception for that or
+        // will we still end up in this `then()` block? Test this!!
         if (res.data.code && res.data.code === 'submission_runner_no_deploy_in_progress') {
           log.info('No previous upload in queue')
           return done()

--- a/tasks/wc.js
+++ b/tasks/wc.js
@@ -135,5 +135,5 @@ module.exports = (gulp, plugins, sake) => {
   })
 
   // the main task to deploy woocommerce.com plugins
-  gulp.task('wc:deploy', gulp.series('wc:validate', 'wc:upload', 'wc:notify'))
+  gulp.task('wc:deploy', gulp.series('wc:validate', 'wc:upload'))
 }


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-17477

# Summary

- Introduces two new environment variables, as auth has changed now:
    - `WC_USERNAME` <-- `woocommerce.com` username
    - `WC_APPLICATION_PASSWORD` <-- application password for the account
- Updates the root API endpoint
- Updates the `wc:validate` task to use the new `deploy/status` endpoint. This lets you know if a deployment is already in progress for the given product ID.
- Previously it looks like deployment was a multi-step process: 1) request an upload URL; 2) actually upload the file; 3) alert Woo the upload was done. Some of these steps are now unnecessary, and the tasks have been removed accordingly.
- We should determine whether we can remove the `request` package. I removed one usage of it, which I think may have been the only one.
- Not yet tested, but it looks like the deployment might be async. So once we make our request, it might be `queued` or basically successful but not "done". We may wish to consider polling the `/deploy/status` endpoint until it reports successfully (depending on how long this process normally takes -- if it's seconds then it might be worth it; if it's multiple minutes then that might be annoying?)

## QA

We're not aware of any sandbox for this API so we'll basically have to test in production! We plan on using [this release](https://github.com/gdcorp-partners/woocommerce-product-documents/pull/70) to test this PR, once both are ready.

### Setup

1. Run a fresh `npm install` to ensure your dependencies are all correct.
1. Follow [instructions to use a development version of Sake](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
2. Switch to the desired branch in your development version of Sake.
3. Ensure there is an `.env` file in your local copy of Sake with `WC_USERNAME` and `WC_APPLICATION_PASSWORD` vars set. You can get these values from the "WooCommerce product deployment API keys (new)" item in 1Password.
4. Perform tests using https://github.com/gdcorp-partners/woocommerce-product-documents/pull/70

### Steps

1. From the plugin's directory, run `sake wc:validate --debug`
    - [x] You see a GET request to `https://woocommerce.com/wp-json/wc/submission/runner/v1/product/deploy/status`
    - [x] Woo response code is `submission_runner_no_deploy_in_progress`
    - [x] Output includes `No previous upload in queue`
    - [x] No errors are thrown.
2. From the plugin's directory, run `sake deploy --debug`
    - [x] Woo API response is successful
    - [x] No errors (note: I actually did get an error because my expectation of the response schema was incorrect, but the actual upload was successful!)
3. Log in to https://woocommerce.com/wp-admin and go to the Products page.
4. Search for and edit Product Documents ( https://woocommerce.com/wp-admin/edit.php?post_type=product&page=view-product&post=238848 )
    - [x] There's a new version uploaded (v1.15.2)
4. Log in to a MWCS TLA and go to WooCommerce > Extensions.
5. In "GoDaddy Included Extensions", search for `documents` to find "Product Documents".
6. Install it.
    - [x] Version 1.15.2 is installed successfully and activates/behaves normally.