### PR TITLE
Add readme.txt header validation

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -97,6 +97,7 @@ module.exports = (gulp, plugins, sake) => {
   gulp.task('deploy:preflight', (done) => {
     let tasks = [
       'shell:git_ensure_clean_working_copy',
+      'validate:readme_headers',
       'lint:scripts',
       'lint:styles'
     ]

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const log = require('fancy-log')
+
+module.exports = (gulp, plugins, sake) => {
+  gulp.task('validate:readme_headers', (done) => {
+    fs.readFile(`${sake.config.paths.src}/readme.txt`, 'utf8', (err, data) => {
+      if (err) sake.throwError(err)
+
+      let requiredHeaders = [
+        'License',
+        'License URI',
+      ]
+
+      if (sake.config.deploy.type === 'wp') {
+        requiredHeaders.push('Stable tag')
+      }
+
+      requiredHeaders.forEach(headerName => {
+        log.info(`Validating readme.txt header ${headerName}`)
+        const regex = new RegExp(headerName + ':(.+)', 'ig')
+        const headerValue = data.match(regex)
+
+        if (! headerValue) {
+          sake.throwError('Missing required header in readme.txt: ' + headerName)
+        }
+      })
+
+      done()
+    })
+  })
+}


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-17729

# Summary

This adds a new task to validate the `readme.txt` headers prior to deployment.

The following are validated for all plugins:

- License
- License URI

The following are validated for .org plugins only:

- Stable tag

We could also make the license ones for .org only. That's the only place it's truly required.

## QA

### Setup

- Configure [using a development version of Sake](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)

### Steps

1. Checkout any plugin.
2. Edit the readme. If it already has `License` headers, remove them.
3. Run `sake validate:readme_headers`
    - [x] You get an error
4. Re-add all headers
    - [x] You do not get any errors