### PR TITLE
Update regex to prevent deleting entire file

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const semver = require('semver')
+const log = require('fancy-log')
 
 module.exports = (gulp, plugins, sake) => {
   // copy files from source to build
@@ -151,7 +152,7 @@ module.exports = (gulp, plugins, sake) => {
 
     return gulp.src(paths, { base: sake.config.paths.src })
       .pipe(filter)
-      .pipe(plugins.replace(/^.*sourceMappingURL=.*$/mg, '')) // remove source mapping references - TODO: consider skipping sourcemaps in compilers instead when running build/deploy tasks
+      .pipe(plugins.replace(/\/\*# sourceMappingURL=.*?\*\/$/mg, '')) // remove source mapping references - TODO: consider skipping sourcemaps in compilers instead when running build/deploy tasks
       .pipe(plugins.replace('\n', '')) // remove an extra line added by libsass/node-sass
       .pipe(filter.restore)
       .pipe(gulp.dest(`${sake.config.paths.build}/${sake.config.plugin.id}`))

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const semver = require('semver')
-const log = require('fancy-log')
 
 module.exports = (gulp, plugins, sake) => {
   // copy files from source to build


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-17793

# Summary

This updates the regex to be less aggressive. It was previously capturing and deleting the entire file comments -- more than just the source mapping comment.

This ensures we only match from the start of the comment.

## QA

First we'll confirm the problem in `master` just to fully confirm the fix.

1. Use a repo like this one: https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim
2. Run `npx sake copy:build`
3. Inspect `less build/woocommerce-gateway-authorize-net-cim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/assets/css/frontend/sv-wc-payment-gateway-payment-form.min.css`
    - [x] It's an empty file

Now we'll confirm the fix:

1. Set up [using a local version of Sake](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
2. Ensure you checkout this PR branch.
3. Navigate back to your https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim repo
4. Run `sake copy:build` <-- note the different command!
3. Inspect `less build/woocommerce-gateway-authorize-net-cim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/assets/css/frontend/sv-wc-payment-gateway-payment-form.min.css`
    - [x] It contains minified CSS code

## After merge

1. Merge & deploy https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim/pull/109 to address missing CSS bug