### PR TITLE
Add testing confirmation before plugin deployment

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -41,6 +41,7 @@ module.exports = (gulp, plugins, sake) => {
 
     let tasks = [
       // preflight checks, will fail the deploy on errors
+      'prompt:tested_release_zip',
       'deploy:preflight',
       // ensure version is bumped
       'bump',

--- a/tasks/prompt.js
+++ b/tasks/prompt.js
@@ -81,6 +81,21 @@ module.exports = (gulp, plugins, sake) => {
     })
   })
 
+  // internal task for prompting whether the release has been tested
+  gulp.task('prompt:tested_release_zip', (done) => {
+    inquirer.prompt([{
+      type: 'confirm',
+      name: 'tested_release_zip',
+      message: 'Has the generated zip file for this release been tested?'
+    }]).then((answers) => {
+      if (answers.tested_release_zip) {
+        done()
+      } else {
+        sake.throwError('Run npx sake zip to generate a zip of this release and test it on a WordPress installation.')
+      }
+    })
+  })
+
   function filterIncrement (value) {
     if (value[1] === 'custom') {
       return 'custom'


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-17916

This adds a confirmation prompt prior to deployment to confirm the release zip has been tested.

## QA

1. [Configure local set up](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
2. Go to any plugin directory and run `sake deploy`
    - [x] You immediately get this prompt: `Has the generated zip file for this release been tested?`
3. Enter `n`
    - [x] Deployment stops with error.
4. Run `sake deploy` again
5. Enter `y`
    - [x] Deployment proceeds (you can CTRL+C once it gets to the version prompt)