### PR TITLE
Force delete when cleaning SVN stuff

### DIFF
--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -46,13 +46,17 @@ module.exports = (gulp, plugins, sake) => {
   gulp.task('clean:wp_trunk', () => {
     return del([
       path.join(sake.getProductionRepoPath(), 'trunk')
-    ])
+    ], {
+      force: true // required to allow deleting outside of current working directory
+    })
   })
 
   // clear wp repo trunk
   gulp.task('clean:wp_assets', () => {
     return del([
       path.join(sake.getProductionRepoPath(), 'assets')
-    ])
+    ], {
+      force: true // required to allow deleting outside of current working directory
+    })
   })
 }


### PR DESCRIPTION
This fixes a bug with .org deployments:

```
[12:31:17] Starting 'clean:wp_trunk'...
[12:31:17] 'clean:wp_trunk' errored after 1.94 ms
[12:31:17] Error: Cannot delete files/directories outside the current working directory. Can be overridden with the `force` option.
    at safeCheck (/home/agibson/www/plugins/wp-content/plugins/woocommerce-sequential-order-numbers/node_modules/del/index.js:37:9)
    at mapper (/home/agibson/www/plugins/wp-content/plugins/woocommerce-sequential-order-numbers/node_modules/del/index.js:83:4)
    at /home/agibson/www/plugins/wp-content/plugins/woocommerce-sequential-order-numbers/node_modules/p-map/index.js:57:28
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[12:31:17] 'copy_to_wp_repo' errored after 5.55 s
[12:31:17] 'deploy_to_wp_repo' errored after 5.55 s
[12:31:17] 'deploy' errored after 14 s
```

When it cleans the SVN dir it's outside of the current working directory. So we need to set the `force` option.