### PR TITLE
Set encoding to false to prevent image corruption

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -152,7 +152,9 @@ module.exports = (gulp, plugins, sake) => {
       })
     }
 
-    return gulp.src(paths, { base: sake.config.paths.src, allowEmpty: true })
+    // encoding: false is required because otherwise images will become corrupted
+    // @link https://github.com/gulpjs/gulp/issues/2790
+    return gulp.src(paths, { base: sake.config.paths.src, allowEmpty: true, encoding: false })
       .pipe(filter)
       .pipe(plugins.replace(/\/\*# sourceMappingURL=.*?\*\/$/mg, '')) // remove source mapping references - TODO: consider skipping sourcemaps in compilers instead when running build/deploy tasks
       .pipe(plugins.replace('\n', '')) // remove an extra line added by libsass/node-sass

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -8,7 +8,7 @@ module.exports = (gulp, plugins, sake) => {
     return gulp.src([
       `${sake.config.paths.build}/${sake.config.plugin.id}/**`,
       `!${sake.config.paths.build}/${sake.config.plugin.id}/**/*.zip`
-    ], { nodir: true, base: sake.config.paths.build }) // exclude empty directories, include plugin dir in zip
+    ], { nodir: true, base: sake.config.paths.build, encoding: false }) // exclude empty directories, include plugin dir in zip, no encoding because it breaks images
       .pipe(plugins.zip(zipFileName))
       .pipe(gulp.dest(sake.config.paths.zipDest))
   })


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-18161

# Summary

This disables encoding, because having it enabled nukes non-text files, such as images and fonts.

Reference: https://github.com/gulpjs/gulp/issues/2790

## QA

- [x] QA steps in https://github.com/gdcorp-partners/woocommerce-pdf-product-vouchers/pull/189 pass