### PR TITLE
Force delete during clean operations

### DIFF
--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -31,7 +31,9 @@ module.exports = (gulp, plugins, sake) => {
     // this will automatically exclude any dotfiles, such as the .git directory
     return del([
       sake.getProductionRepoPath() + '**/*'
-    ])
+    ], {
+      force: true // required to allow deleting outside of current working directory
+    })
   })
 
   // delete prerelease
@@ -39,7 +41,9 @@ module.exports = (gulp, plugins, sake) => {
     return del([
       sake.getPrereleasesPath() + sake.config.plugin.id + '*.zip',
       sake.getPrereleasesPath() + sake.config.plugin.id + '*.txt'
-    ])
+    ], {
+      force: true // required to allow deleting outside of current working directory
+    })
   })
 
   // clear wp repo trunk


### PR DESCRIPTION
This enables force-deletes during a few more clean operations. This fixes errors we encountered during deployments, after having run `npx sake pre`. Related to: https://godaddy.slack.com/archives/C04L7S7JJE9/p1753310697611109?thread_ts=1753297647.357849&cid=C04L7S7JJE9

## QA

1. Follow instructions to use [this development version of Sake](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
2. For now, checkout Sake `master` branch. This is so we can confirm the error first.
3. Choose which plugin you want to work with for testing. **We won't be deploying anything so you can pick any one.** I'm using Moneris.
4. Ensure you have `SAKE_PRE_RELEASE_PATH` configured in your `.bash_profile`
5. Inside that path, create a file called `YOUR_CHOSEN_PLUGIN-1.txt`. I'm using Moneris so I created `woocommerce-gateway-moneris-1.txt`
6. Navigate to your chosen plugin's directory. So I'm in `woocommerce-gateway-moneris/`
7. Run `sake clean:prerelease`
    - [ ] You get this error: `Error: Cannot delete files/directories outside the current working directory. Can be overridden with the `force` option.`
    - [ ] Your pre-release folder is still populated.
8. Checkout Sake branch `fix/force-deletes`
9. Re-run `sake:cleanprerelease`
    - [ ] You do not get any errors
    - [ ] The `YOUR_CHOSEN_PLUGIN-1.txt` file has been deleted from your pre-release directory