### PR TITLE
Remove line break replacement

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -157,7 +157,6 @@ module.exports = (gulp, plugins, sake) => {
     return gulp.src(paths, { base: sake.config.paths.src, allowEmpty: true, encoding: false })
       .pipe(filter)
       .pipe(plugins.replace(/\/\*# sourceMappingURL=.*?\*\/$/mg, '')) // remove source mapping references - TODO: consider skipping sourcemaps in compilers instead when running build/deploy tasks
-      .pipe(plugins.replace('\n', '')) // remove an extra line added by libsass/node-sass
       .pipe(filter.restore)
       .pipe(gulp.dest(`${sake.config.paths.build}/${sake.config.plugin.id}`))
   })


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-18482

# Summary

This completely removes a replacement that was nuking line breaks. This was effectively minifying JS files, but in an improper fashion that resulted in breaking a JS file in https://godaddy-corp.atlassian.net/browse/MWC-18482

## Details

I'm not sure why this suddenly became a problem when it wasn't one before, but I do see that this is a dangerous behaviour we shouldn't be doing and there isn't much benefit.

## QA

1. Use this branch as [a development version of Sake](https://github.com/godaddy-wordpress/sake/wiki/Using-a-development-version-of-Sak%C3%A9)
2. In the Customer/Order/Coupon Export repo, run `sake zip` to generate a zip file
3. Upload it to a WordPress site
4. Visit any admin page
    - [x] No JS errors
5. Run an order or customer export
    - [x] Export runs successfully