### PR TITLE
Skip phpstan config & agent files when building

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -58,6 +58,7 @@ const copyBuildTask = (done) => {
     `!${sake.config.paths.src}/**/test.sh`,
     `!${sake.config.paths.src}/**/readme.md`,
     `!${sake.config.paths.src}/**/.{*}`, // any file starting with a dot
+    `!${sake.config.paths.src}/**/phpstan.neon`,
 
     // skip tartufo files
     `!${sake.config.paths.src}/**/tool.tartufo`,

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -58,7 +58,6 @@ const copyBuildTask = (done) => {
     `!${sake.config.paths.src}/**/test.sh`,
     `!${sake.config.paths.src}/**/readme.md`,
     `!${sake.config.paths.src}/**/.{*}`, // any file starting with a dot
-    `!${sake.config.paths.src}/**/phpstan.neon`,
 
     // skip tartufo files
     `!${sake.config.paths.src}/**/tool.tartufo`,

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -58,6 +58,7 @@ const copyBuildTask = (done) => {
     `!${sake.config.paths.src}/**/test.sh`,
     `!${sake.config.paths.src}/**/readme.md`,
     `!${sake.config.paths.src}/**/.{*}`, // any file starting with a dot
+    `!${sake.config.paths.src}/**/phpstan.neon`,
 
     // skip tartufo files
     `!${sake.config.paths.src}/**/tool.tartufo`,
@@ -77,6 +78,10 @@ const copyBuildTask = (done) => {
     // skip build config files
     `!${sake.config.paths.src}/**/sake.config.js`,
     `!${sake.config.paths.src}/**/postcss.config.js`,
+
+    // skip AI files
+    `!${sake.config.paths.src}/**/CLAUDE.md`,
+    `!${sake.config.paths.src}/**/.agents{,/**}`,
   ]
 
   if (sake.config.framework) {

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -80,6 +80,7 @@ const copyBuildTask = (done) => {
     `!${sake.config.paths.src}/**/postcss.config.js`,
 
     // skip AI files
+    `!${sake.config.paths.src}/**/AGENTS.md`,
     `!${sake.config.paths.src}/**/CLAUDE.md`,
     `!${sake.config.paths.src}/**/.agents{,/**}`,
   ]


### PR DESCRIPTION
# Summary

This updates the copy task to skip copying over ethe following file types:

- `phpstan.neon` config file
- `AGENTS.md` file
- `CLAUDE.md` file
- `.agents/` directory

## QA

1. Use this branch of sake
2. Run `sake build`
    - [x] Above mentioned file types are excluded