### PR TITLE
Fix zip corruption in pre command output

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -174,10 +174,12 @@ const copyPrereleaseTask = (done) => {
 
   const filter = gulpFilter([`**/${filename}.txt`], { restore: true })
 
+  // encoding: false is required so the zip isn't corrupted by utf-8 round-tripping
+  // @link https://github.com/gulpjs/gulp/issues/2790
   return gulp.src([
     `${sake.config.paths.build}/${sake.config.plugin.id}*.zip`,
     `${sake.config.paths.build}/${sake.config.plugin.id}/${filename}.txt`
-  ]).pipe(filter)
+  ], { encoding: false }).pipe(filter)
     .pipe(rename({ prefix: sake.config.plugin.id + '_' }))
     .pipe(filter.restore)
     .pipe(gulp.dest(sake.getPrereleasesPath()))


### PR DESCRIPTION
## Summary
- `copyPrereleaseTask` in `tasks/copy.js` was reading the build zip via `gulp.src` without `encoding: false`, causing gulp 5 to round-trip the binary through utf-8 and corrupt the archive.
- The same `encoding: false` flag is already applied in `copyBuildTask`, `copyWpAssetsTask`, and `zipTask` for the same reason — this brings `copyPrereleaseTask` in line.
- See [gulpjs/gulp#2790](https://github.com/gulpjs/gulp/issues/2790) for the underlying gulp behavior.

Fixes godaddy-wordpress/sake#145
Jira: [MWC-19894](https://godaddy-corp.atlassian.net/browse/MWC-19894)

## Test plan
- [x] Run `sake build` then `sake pre` in a plugin directory
- [x] Unzip the resulting prerelease zip — confirm it extracts without errors
- [x] Upload the zip to a WordPress site as a plugin — confirm install succeeds without `PCLZIP_ERR_BAD_FORMAT` or unpack warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)