### PR TITLE
Docs: Update skyverge/sake references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Requires:
 ### Installation:
 
 ```
-$ npm i skyverge/sake
+$ npm i godaddy-wordpress/sake
 ```
 
 ### Update to latest
 
 ```
-$ npm update skyverge/sake
+$ npm update godaddy-wordpress/sake
 ```
 
 > [!NOTE]
-> Sake is currently not versioned, but a specific commit may be provided when installing, such as `skyverge/sake#0d5ec6622a6845f695d9e8ed04f4db08bd0e4986`.
+> Sake is currently not versioned, but a specific commit may be provided when installing, such as `godaddy-wordpress/sake#0d5ec6622a6845f695d9e8ed04f4db08bd0e4986`.
 
 > [!IMPORTANT]
 > Refer to the [Setting up your environment](https://github.com/godaddy-wordpress/sake/wiki/Plugin-Deployment#setting-up-your-environment) section for the revised prerequisites, notably replacement of now-unused `WC_CONSUMER_KEY` and `WC_CONSUMER_SECRET` variables with new required `WC_USERNAME` and `WC_APPLICATION_PASSWORD` variables.
@@ -33,7 +33,7 @@ Ensure you're in a plugin directory (ie `wc-plugins/woocommerce-address-validati
 $ npx sake build
 ```
 
-You can also [pass options](https://github.com/skyverge/sake/wiki/CLI-options) to tasks.
+You can also [pass options](https://github.com/godaddy-wordpress/sake/wiki/CLI-options) to tasks.
 
 ### See a list of available tasks
 
@@ -43,6 +43,6 @@ $ npx sake --tasks
 
 ## Developing
 
-1. Make sure to read & understand [configuration](https://github.com/skyverge/sake/wiki/Configuration).
+1. Make sure to read & understand [configuration](https://github.com/godaddy-wordpress/sake/wiki/Configuration).
 2. Use [Standard JS](https://standardjs.com/) coding style.
 3. Test against forks of the development and production repos.

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/skyverge/sake.git"
+    "url": "https://github.com/godaddy-wordpress/sake.git"
   },
   "bugs": {
-    "url": "https://github.com/skyverge/sake/issues?state=open"
+    "url": "https://github.com/godaddy-wordpress/sake/issues?state=open"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
# Summary

Repoints the remaining `skyverge/sake` references to `godaddy-wordpress/sake` following the GitHub org migration. Covers the README install/update commands, the pinned-commit install example, the two wiki links, and the `package.json` `repository` and `bugs` URLs.

## Details

The `skyverge/sake` org links were stale after the move to `godaddy-wordpress` — `README.md` line 25 already used the new org while the rest didn't. The published `@skyverge/eslint-config` dependency and the `skyverge.com` homepage are intentionally left unchanged: the former is an npm package name, the latter a company URL, neither a GitHub org reference.

## QA

- [ ] Checks pass
- [ ] The updated README links resolve to live `godaddy-wordpress/sake` wiki pages

## Before merge

- [ ] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [ ] This PR makes the appropriate modifications to documentation or explains why none are needed
- [ ] This change does not impact usage or expected outputs of covered code
- [ ] I've bumped the AI Assistant framework version if one is available