### PR TITLE
Change product ID handling for Woo Marketplace plugins 

### DIFF
--- a/lib/sake.js
+++ b/lib/sake.js
@@ -457,6 +457,7 @@ function initializeSake(config, options) {
 
       if (match && match[1]) {
         id = match[1]
+        log.warn(chalk.yellow('Woo Product ID found via Woo header in main plugin file. Recommended to define it in sake.config.js instead.'))
       }
     }
 

--- a/lib/sake.js
+++ b/lib/sake.js
@@ -240,8 +240,12 @@ function initializeSake(config, options) {
         config.paths.wpAssets = 'wp-assets'
       }
 
-      if (config.deploy.type === 'wc' && !config.deploy.wooId) {
-        config.deploy.wooId = this.getPluginWooId()
+      if (config.deploy.type === 'wc') {
+        const headerWooId = this.getPluginWooId()
+
+        if (!config.deploy.wooId) {
+          config.deploy.wooId = headerWooId
+        }
       }
     }
 

--- a/lib/sake.js
+++ b/lib/sake.js
@@ -240,6 +240,9 @@ function initializeSake(config, options) {
         config.paths.wpAssets = 'wp-assets'
       }
 
+      if (config.deploy.type === 'wc') {
+        config.deploy.wooId = this.getPluginWooId()
+      }
     }
 
     // `docs` represents the docs repo for this plugin. We'll try to determine the repo from the following values (in order):

--- a/lib/sake.js
+++ b/lib/sake.js
@@ -240,9 +240,6 @@ function initializeSake(config, options) {
         config.paths.wpAssets = 'wp-assets'
       }
 
-      if (config.deploy.type === 'wc') {
-        config.deploy.wooId = this.getPluginWooId()
-      }
     }
 
     // `docs` represents the docs repo for this plugin. We'll try to determine the repo from the following values (in order):

--- a/lib/sake.js
+++ b/lib/sake.js
@@ -240,7 +240,7 @@ function initializeSake(config, options) {
         config.paths.wpAssets = 'wp-assets'
       }
 
-      if (config.deploy.type === 'wc') {
+      if (config.deploy.type === 'wc' && !config.deploy.wooId) {
         config.deploy.wooId = this.getPluginWooId()
       }
     }

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -110,7 +110,7 @@ const deployTask = (done) => {
     deployCreateReleasesTask,
   ]
 
-  if (sake.config.deploy.wooId && sake.config.deploy.type === 'wc') {
+  if (sake.config.deploy.type === 'wc') {
     tasks.push(promptWcUploadTask)
   }
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -136,7 +136,8 @@ const deployPreflightTask = (done) => {
     lintStylesTask
   ]
 
-  if (sake.config.deploy.type === 'wc') {
+  if (sake.config.deploy.type === 'wc' && !sake.config.deploy.wooId) {
+    log.warn(chalk.yellow('Woo Product ID not defined in sake.config.js, searching in the main plugin file.'))
     tasks.unshift(searchWtUpdateKeyTask)
   }
 
@@ -162,6 +163,10 @@ const searchWtUpdateKeyTask = (done) => {
 
     // matches " * Woo: ProductId:ProductKey" in the main plugin file PHPDoc
     const phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+)/ig)
+
+    if (phpDocMatch) {
+      log.warn(chalk.yellow('Woo Product ID found via Woo header in main plugin file. Recommended to define it in sake.config.js instead.'))
+    }
     // matches legacy woothemes_queue_update() usage in the main plugin file
     const phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -110,7 +110,7 @@ const deployTask = (done) => {
     deployCreateReleasesTask,
   ]
 
-  if (sake.config.deploy.type === 'wc') {
+  if (sake.config.deploy.wooId && sake.config.deploy.type === 'wc') {
     tasks.push(promptWcUploadTask)
   }
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -136,10 +136,6 @@ const deployPreflightTask = (done) => {
     lintStylesTask
   ]
 
-  if (sake.config.deploy.type === 'wc') {
-    tasks.unshift(searchWtUpdateKeyTask)
-  }
-
   gulp.parallel(tasks)(done)
 }
 deployPreflightTask.displayName = 'deploy:preflight'

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -136,6 +136,10 @@ const deployPreflightTask = (done) => {
     lintStylesTask
   ]
 
+  if (sake.config.deploy.type === 'wc') {
+    tasks.unshift(searchWtUpdateKeyTask)
+  }
+
   gulp.parallel(tasks)(done)
 }
 deployPreflightTask.displayName = 'deploy:preflight'

--- a/tasks/wc.js
+++ b/tasks/wc.js
@@ -11,8 +11,7 @@ const wcRoot = 'https://woocommerce.com/wp-json/wc/submission/runner/v1'
 
 let apiOptions = {
   username: process.env.WC_USERNAME,
-  password: process.env.WC_APPLICATION_PASSWORD,
-  product_id: sake.config.deploy.wooId
+  password: process.env.WC_APPLICATION_PASSWORD
 }
 
 let getApiURL = (endpoint) => {

--- a/tasks/wc.js
+++ b/tasks/wc.js
@@ -11,7 +11,8 @@ const wcRoot = 'https://woocommerce.com/wp-json/wc/submission/runner/v1'
 
 let apiOptions = {
   username: process.env.WC_USERNAME,
-  password: process.env.WC_APPLICATION_PASSWORD
+  password: process.env.WC_APPLICATION_PASSWORD,
+  product_id: sake.config.deploy.wooId
 }
 
 let getApiURL = (endpoint) => {


### PR DESCRIPTION
# Summary
Changes handling for the `wooID` config so plugins deployed to Woo can pass their Validation test suite.

The Woo marketplace Validation tests throw a warning when the product ID is included in the submitted plugin header files (header line `Woo:`) since they prefer to add that themselves during upload processing. Those tests are a criteria for the upcoming "Excellence Verified" badge, with warnings preventing badge qualification.

At the same time, Woo REQUIRES the `product_id` header for programmatic deployment via their product submission API ([docs](https://developer.woocommerce.com/docs/woo-marketplace/product-update-guidelines/#programmatically-uploading-new-versions)), so we still need to be able to source that programmatically during the deploy process.

This PR changes handling to source the product ID from `deploy.wooId` in the Sake config instead, and also adds warning logs when the `Woo` plugin header is detected.

## Usage
Plugins looking to pass validation tests AND support programmatic deploys should remove the `Woo` line from their plugin header and instead write just the ID to their `sake.config.js` file, in the following shape:

```
module.exports = {
	[...],
	deploy: {
		wooId: "12345",
	},
    [...],
};

```


### ⚠️ Note
SkyVerge plugins have historically formatted their plugin header as `Woo: <ProductId>:<ProductKey>`. Only the `<ProductId>` portion should be entered as the `deploy.wooId` value in the Sake config.


## QA
- [x] `sake build` builds plugin w/o `Woo` header
- [x] `sake deploy` successfully deploys to Woo
- [x] Woo Validation test passes with no warning re: `Woo` header